### PR TITLE
Add support for signing pre-hashed message

### DIFF
--- a/tkeysign.go
+++ b/tkeysign.go
@@ -35,6 +35,8 @@ var (
 	rspGetSig         = appCmd{0x08, "rspGetSig", tkeyclient.CmdLen128}
 	cmdGetNameVersion = appCmd{0x09, "cmdGetNameVersion", tkeyclient.CmdLen1}
 	rspGetNameVersion = appCmd{0x0a, "rspGetNameVersion", tkeyclient.CmdLen32}
+	cmdSignPhData     = appCmd{0x0b, "cmdSignPhData", tkeyclient.CmdLen128}
+	rspSignPhData     = appCmd{0x0c, "rspSigPhnData", tkeyclient.CmdLen4}
 )
 
 const MaxSignSize = 4096
@@ -267,4 +269,39 @@ func (s Signer) getSig() ([]byte, error) {
 	// Skip frame header, app header, and status; returning size of
 	// ed25519 signature
 	return rx[3 : 3+64], nil
+}
+
+// SignPh signs a SHA512 pre-hashed message in data and returns an
+// ed25519ph signature.
+func (s Signer) SignPh(data [64]byte) ([]byte, error) {
+	id := 2
+	tx, err := tkeyclient.NewFrameBuf(cmdSignPhData, id)
+	if err != nil {
+		return nil, fmt.Errorf("NewFrameBuf: %w", err)
+	}
+
+	copy(tx[2:], data[:])
+
+	tkeyclient.Dump("LoadSignPhData tx", tx)
+	if err = s.tk.Write(tx); err != nil {
+		return nil, fmt.Errorf("Write: %w", err)
+	}
+
+	// Wait for reply
+	rx, _, err := s.tk.ReadFrame(rspSignPhData, id)
+	if err != nil {
+		return nil, fmt.Errorf("ReadFrame: %w", err)
+	}
+
+	if rx[2] != tkeyclient.StatusOK {
+		return nil, fmt.Errorf("SignData NOK")
+	}
+
+	// Get the signature
+	signature, err := s.getSig()
+	if err != nil {
+		return nil, fmt.Errorf("getSig: %w", err)
+	}
+
+	return signature, nil
 }


### PR DESCRIPTION
Test in collaboration with [tkey-device-signer](https://github.com/tillitis/tkey-device-signer/pull/5) and [tkey-sign-cli](https://github.com/tillitis/tkey-sign-cli/pull/4)